### PR TITLE
Issue demonstration, incorrect error for android.test.canceled product

### DIFF
--- a/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/MainActivity.java
+++ b/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/MainActivity.java
@@ -116,7 +116,8 @@ public class MainActivity extends Activity implements IabBroadcastListener,
 
     // SKUs for our products: the premium upgrade (non-consumable) and gas (consumable)
     static final String SKU_PREMIUM = "premium";
-    static final String SKU_GAS = "gas";
+//    static final String SKU_GAS = "gas";
+    static final String SKU_GAS = "android.test.canceled"; // Generates incorrect error code, see IABHELPER_UNKNOWN_ERROR but expecting IABHELPER_USER_CANCELLED. Looking at you, IabHelper.java.
 
     // SKU for our subscription (infinite gas)
     static final String SKU_INFINITE_GAS_MONTHLY = "infinite_gas_monthly";


### PR DESCRIPTION
- Expecting IabHelper.java to generate IABHELPER_USER_CANCELLED but
  seeing IABHELPER_UNKNOWN_ERROR when using Google IAB's special
  "android.test.canceled" product id. See also:
  https://developer.android.com/google/play/billing/billing_testing.html
