### PR TITLE
Fix getPurchases crash

### DIFF
--- a/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
+++ b/TrivialDrive/app/src/main/java/com/example/android/trivialdrivesample/util/IabHelper.java
@@ -224,6 +224,7 @@ public class IabHelper {
             @Override
             public void onServiceDisconnected(ComponentName name) {
                 logDebug("Billing service disconnected.");
+                mSetupDone = false;
                 mService = null;
             }
 


### PR DESCRIPTION
When service disconnected the mService = null and in function int queryPurchases(Inventory inv, String itemType) call mService.getPurchases will crash
